### PR TITLE
Set default environment to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Twilio API credentials
 # Found at https://www.twilio.com/user/account/settings
-export TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
-export TWILIO_AUTH_TOKEN=your-token
+TWILIO_ACCOUNT_SID=ACXXXXXXXXXXXXXXXXXXXXXX
+TWILIO_AUTH_TOKEN=your-token
 
 # Twilio phone number
 # Purchase one at https://www.twilio.com/user/account/phone-numbers
-export TWILIO_NUMBER=+15551234567
+TWILIO_NUMBER=+15551234567

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'dotenv'
 gem 'data_mapper'
 gem 'dm-postgres-adapter'
 gem 'haml', '4.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       dm-core (~> 1.2.0)
     do_postgres (0.10.17)
       data_objects (= 0.10.17)
+    dotenv (2.7.6)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
@@ -122,6 +123,7 @@ DEPENDENCIES
   data_mapper
   database_cleaner
   dm-postgres-adapter
+  dotenv
   haml (= 4.0.7)
   nokogiri (~> 1.8)
   pg (= 0.20.0)
@@ -133,4 +135,4 @@ DEPENDENCIES
   twilio-ruby (>= 5.0.0)
 
 BUNDLED WITH
-   1.15.1
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Warm Transfer: Transfer support calls from one agent to another using Ruby and Sinatra
 [![Build and test](https://github.com/TwilioDevEd/warm-transfer-sinatra/actions/workflows/build_test.yml/badge.svg)](https://github.com/TwilioDevEd/warm-transfer-sinatra/actions/workflows/build_test.yml)
 
-## Local development
+## Get started
 
 This project is built using the [Sinatra](http://www.sinatrarb.com/) web framework.
 
@@ -27,8 +27,6 @@ This project is built using the [Sinatra](http://www.sinatrarb.com/) web framewo
  You can find your `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` in your
  [Twilio Account Settings](https://www.twilio.com/user/account/settings).
  You will also need a `TWILIO_NUMBER`, which you may find [here](https://www.twilio.com/user/account/phone-numbers/incoming).
-
- Run `source .env` to export the environment variables
 
 1. Create development and test databases
 
@@ -78,6 +76,14 @@ This project is built using the [Sinatra](http://www.sinatrarb.com/) web framewo
 
 
 That's it!
+
+### Configure Development vs Production Settings
+
+By default, this application will run in production mode - stack traces will not be visible in the web browser. If you would like to run this application in development locally, change the `APP_ENV` variable in your `.env` file.
+
+`APP_ENV=development`
+
+For more about development vs production, visit [Sinatra's configuration page](http://sinatrarb.com/configuration.html).
 
 ## How to Demo
 

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
-require 'sinatra/base'
+require 'dotenv'
+require 'sinatra'
 require "sinatra/json"
 require 'sinatra/config_file'
 require 'tilt/haml'
@@ -10,10 +11,16 @@ require_relative 'lib/twilio_capability'
 require_relative 'lib/twiml_generator'
 require_relative 'lib/caller'
 
-ENV['RACK_ENV'] ||= 'development'
+# Load environment configuration
+Dotenv.load
+
+# Set the environment after dotenv loads
+# Default to production
+environment = (ENV['APP_ENV'] || ENV['RACK_ENV'] || :production).to_sym
+set :environment, environment
 
 require 'bundler'
-Bundler.require :default, ENV['RACK_ENV'].to_sym
+Bundler.require :default, environment
 
 module WarmTransfer
   class App < Sinatra::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = 'test'
 
 require_relative File.join('..', 'app')
 


### PR DESCRIPTION
Set default environment to production.

Changes in the PR:

- Set `APP_ENV` to `production`
- Install dotenv
- Update README.
